### PR TITLE
Fix: add mp_500_ prefix for wheel and caster joints to match Gazebo Plugin

### DIFF
--- a/robot_model/xacros/mp_500_body.urdf.xacro
+++ b/robot_model/xacros/mp_500_body.urdf.xacro
@@ -51,7 +51,7 @@ Contributor: Adarsh Karan K P
 
     <!-- Caster Wheel-->
     <xacro:mp_500_caster_wheel
-      wheel_prefix="caster_wheel"
+      wheel_prefix="mp_500_caster_wheel"
       parent_link="base_footprint" 
       wheel_joint_type="fixed"
       >
@@ -60,7 +60,7 @@ Contributor: Adarsh Karan K P
 
     <!-- Wheels-->
     <xacro:mp_500_wheel
-      wheel_prefix="wheel_right"
+      wheel_prefix="mp_500_wheel_right"
       parent_link="base_link" 
       wheel_joint_type="revolute"
       visual_origin_rpy="0 0 3.14"
@@ -69,7 +69,7 @@ Contributor: Adarsh Karan K P
     </xacro:mp_500_wheel>
 
     <xacro:mp_500_wheel
-      wheel_prefix="wheel_left"
+      wheel_prefix="mp_500_wheel_left"
       parent_link="base_link" 
       wheel_joint_type="revolute"
       visual_origin_rpy="0 0 0"


### PR DESCRIPTION
### **Fix: Wheel Joint Prefix Consistency in MP-500 URDF**

This update resolves an inconsistency between the URDF model and the Gazebo plugin configuration for the Neobotix MP-500 robot.
Previously, the Gazebo `JointStatePublisher` and `DiffDrive` plugins expected joint names with the `mp_500_` prefix, while the URDF defined them without it. This mismatch caused Gazebo to fail to find the wheel joints, resulting in missing `/joint_states` updates and disabled odometry publishing.

#### **Changes Made**

* Added `mp_500_` prefix to all wheel and caster joint definitions in `robot_model/xacros/mp_500_body.urdf.xacro`
* Updated joint names for:

  * `mp_500_wheel_left_joint`
  * `mp_500_wheel_right_joint`
  * `mp_500_caster_wheel_joint`
* Ensured consistent naming across URDF and Gazebo plugin configurations

#### **Impact**

* Fixes the following runtime errors:

  ```
  [Err] [JointStatePublisher.cc:78] Joint with name[mp_500_wheel_left_joint] not found.
  [Err] [JointStatePublisher.cc:78] Joint with name[mp_500_wheel_right_joint] not found.
  ```
* Restores correct joint state publishing and enables odometry updates on `/odom`
* Allows the MP-500 robot to respond properly to `/cmd_vel` velocity commands in simulation

#### **Verification**

Tested on:

* **ROS 2 Jazzy**
* **Gazebo Harmonic (gz-sim)**
* Using `ros2 launch neo_mp_500-2 bringup_sim.launch.py` with default `neo_workshop` world

Robot now spawns and moves as expected, with stable `/odom` and `/joint_states` topics.

